### PR TITLE
disable Japanese extra on Windows

### DIFF
--- a/laserembeddings/preprocessing.py
+++ b/laserembeddings/preprocessing.py
@@ -71,7 +71,7 @@ class Tokenizer:
         self.normalizer = MosesPunctNormalizer(lang=lang)
         self.tokenizer = MosesTokenizer(lang=lang)
         self.mecab_tokenizer = MeCab.Tagger(
-            "-O wakati -b 50000") if MeCab is not None else None
+            "-O wakati -b 50000") if lang == 'ja' else None
 
     def tokenize(self, text: str) -> str:
         """Tokenizes a text and returns the tokens as a string"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ subword-nmt = "^0.3.6"
 numpy = "^1.15.4"
 sacremoses = "0.0.35"
 transliterate = "1.10.2"
-mecab-python3 = { version = "^0.996.2", optional = true }
-jieba = { version = "0.39", optional = true }
+mecab-python3 = { version = "^0.996.3", markers = "sys_platform != 'win32'", optional = true }
+jieba = { version = "^0.42.1", optional = true }
 
 [tool.poetry.dev-dependencies]
 pytest = "^4.6"


### PR DESCRIPTION
Japanese extra will be disabled on windows until wheels are available for windows. This PR also implements a fix that will prevent Laser from complaining when mecab-python3 was installed but is not working.

Context:

Mecab-python3 does not provide wheels for windows (https://github.com/SamuraiT/mecab-python3/issues/31) and it looks like there's no easy solution for Windows for now (without having to install Mecab separately or without compiling).

Fixes #16 