### PR TITLE
Fix BPE codes adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,4 @@ Now, have a coffee ☕️ and wait for the test to finish.
 The similarity report will be generated here: [tests/report/comparison-with-LASER.md](tests/report/comparison-with-LASER.md).
 
 
+

--- a/README.md
+++ b/README.md
@@ -191,3 +191,4 @@ SIMILARITY_TEST=1 poetry run pytest tests/test_laser.py
 Now, have a coffee ☕️ and wait for the test to finish.
 
 The similarity report will be generated here: [tests/report/comparison-with-LASER.md](tests/report/comparison-with-LASER.md).
+

--- a/README.md
+++ b/README.md
@@ -194,3 +194,4 @@ The similarity report will be generated here: [tests/report/comparison-with-LASE
 
 
 
+

--- a/README.md
+++ b/README.md
@@ -192,3 +192,4 @@ Now, have a coffee ☕️ and wait for the test to finish.
 
 The similarity report will be generated here: [tests/report/comparison-with-LASER.md](tests/report/comparison-with-LASER.md).
 
+

--- a/laserembeddings/__main__.py
+++ b/laserembeddings/__main__.py
@@ -88,7 +88,7 @@ def main():
         print_usage()
         return
 
-    if any([arg == '--help' for arg in sys.argv]):
+    if any(arg == '--help' for arg in sys.argv):
         print_usage()
         return
 

--- a/laserembeddings/embedding.py
+++ b/laserembeddings/embedding.py
@@ -1,4 +1,5 @@
-from typing import Optional, List, Union, BinaryIO
+from typing import Optional, List, Union
+from io import BufferedIOBase
 
 import numpy as np
 
@@ -12,7 +13,7 @@ class BPESentenceEmbedding:
     LASER embeddings computation from BPE-encoded sentences.
 
     Args:
-        encoder (str or BinaryIO): the path to LASER's encoder PyTorch model,
+        encoder (str or BufferedIOBase): the path to LASER's encoder PyTorch model,
             or a binary-mode file object.
         max_sentences (int, optional): see ``.encoder.SentenceEncoder``.
         max_tokens (int, optional): see ``.encoder.SentenceEncoder``.
@@ -22,7 +23,7 @@ class BPESentenceEmbedding:
     """
 
     def __init__(self,
-                 encoder: Union[str, BinaryIO],
+                 encoder: Union[str, BufferedIOBase],
                  max_sentences: Optional[int] = None,
                  max_tokens: Optional[int] = 12000,
                  stable: bool = False,

--- a/laserembeddings/encoder.py
+++ b/laserembeddings/encoder.py
@@ -3,7 +3,7 @@
 # - code formatting
 # - buffered_arange: fix to avoid unnecessary warning on PyTorch >= 1.4.0
 
-# pylint: disable=redefined-builtin, consider-using-enumerate, arguments-differ, fixme, abstract-method
+# pylint: disable=redefined-builtin, consider-using-enumerate, arguments-differ, fixme, abstract-method, consider-using-from-import
 
 from collections import namedtuple
 
@@ -192,8 +192,7 @@ class Encoder(nn.Module):
         x = x.transpose(0, 1)
 
         # pack embedded source tokens into a PackedSequence
-        packed_x = nn.utils.rnn.pack_padded_sequence(x,
-                                                     src_lengths.data.cpu())
+        packed_x = nn.utils.rnn.pack_padded_sequence(x, src_lengths.data.cpu())
 
         # apply LSTM
         if self.bidirectional:

--- a/laserembeddings/laser.py
+++ b/laserembeddings/laser.py
@@ -1,4 +1,5 @@
-from typing import Dict, Any, Union, List, TextIO, BinaryIO, Optional
+from typing import Dict, Any, Union, List, Optional
+from io import TextIOBase, BufferedIOBase
 import os
 
 import numpy as np
@@ -17,11 +18,11 @@ class Laser:
     The pipeline is: ``Tokenizer.tokenize`` -> ``BPE.encode_tokens`` -> ``BPESentenceEmbedding.embed_bpe_sentences``
 
     Args:
-        bpe_codes (str or TextIO, optional): the path to LASER's BPE codes (``93langs.fcodes``),
+        bpe_codes (str or TextIOBase, optional): the path to LASER's BPE codes (``93langs.fcodes``),
             or a text-mode file object. If omitted, ``Laser.DEFAULT_BPE_CODES_FILE`` is used.
-        bpe_codes (str or TextIO, optional): the path to LASER's BPE vocabulary (``93langs.fvocab``),
+        bpe_codes (str or TextIOBase, optional): the path to LASER's BPE vocabulary (``93langs.fvocab``),
             or a text-mode file object. If omitted, ``Laser.DEFAULT_BPE_VOCAB_FILE`` is used.
-        encoder (str or BinaryIO, optional): the path to LASER's encoder PyToch model (``bilstm.93langs.2018-12-26.pt``),
+        encoder (str or BufferedIOBase, optional): the path to LASER's encoder PyToch model (``bilstm.93langs.2018-12-26.pt``),
             or a binary-mode file object. If omitted, ``Laser.DEFAULT_ENCODER_FILE`` is used.
         tokenizer_options (Dict[str, Any], optional): additional arguments to pass to the tokenizer.
             See ``.preprocessing.Tokenizer``.
@@ -43,9 +44,9 @@ class Laser:
                                         'bilstm.93langs.2018-12-26.pt')
 
     def __init__(self,
-                 bpe_codes: Optional[Union[str, TextIO]] = None,
-                 bpe_vocab: Optional[Union[str, TextIO]] = None,
-                 encoder: Optional[Union[str, BinaryIO]] = None,
+                 bpe_codes: Optional[Union[str, TextIOBase]] = None,
+                 bpe_vocab: Optional[Union[str, TextIOBase]] = None,
+                 encoder: Optional[Union[str, BufferedIOBase]] = None,
                  tokenizer_options: Optional[Dict[str, Any]] = None,
                  embedding_options: Optional[Dict[str, Any]] = None):
 

--- a/laserembeddings/preprocessing.py
+++ b/laserembeddings/preprocessing.py
@@ -1,11 +1,12 @@
-from typing import TextIO, Union, Optional
+from typing import Union, Optional
+from io import TextIOBase
 
 from sacremoses import MosesPunctNormalizer, MosesTokenizer
 from sacremoses.util import xml_unescape
 from subword_nmt.apply_bpe import BPE as subword_nmt_bpe, read_vocabulary
 from transliterate import translit
 
-from .utils import BPECodesAdapter
+from .utils import adapt_bpe_codes
 
 # Extras
 try:
@@ -124,25 +125,25 @@ class BPE:
     BPE encoder.
 
     Args:
-        bpe_codes (str or TextIO): the path to LASER's BPE codes (``93langs.fcodes``),
+        bpe_codes (str or TextIOBase): the path to LASER's BPE codes (``93langs.fcodes``),
             or a text-mode file object.
-        bpe_codes (str or TextIO): the path to LASER's BPE vocabulary (``93langs.fvocab``),
+        bpe_codes (str or TextIOBase): the path to LASER's BPE vocabulary (``93langs.fvocab``),
             or a text-mode file object.
     """
 
-    def __init__(self, bpe_codes: Union[str, TextIO],
-                 bpe_vocab: Union[str, TextIO]):
+    def __init__(self, bpe_codes: Union[str, TextIOBase],
+                 bpe_vocab: Union[str, TextIOBase]):
 
         f_bpe_codes = None
         f_bpe_vocab = None
 
         try:
             if isinstance(bpe_codes, str):
-                f_bpe_codes = open(bpe_codes, 'r', encoding='utf-8')
+                f_bpe_codes = open(bpe_codes, 'r', encoding='utf-8')  # pylint: disable=consider-using-with
             if isinstance(bpe_vocab, str):
-                f_bpe_vocab = open(bpe_vocab, 'r', encoding='utf-8')
+                f_bpe_vocab = open(bpe_vocab, 'r', encoding='utf-8')  # pylint: disable=consider-using-with
 
-            self.bpe = subword_nmt_bpe(codes=BPECodesAdapter(f_bpe_codes
+            self.bpe = subword_nmt_bpe(codes=adapt_bpe_codes(f_bpe_codes
                                                              or bpe_codes),
                                        vocab=read_vocabulary(f_bpe_vocab
                                                              or bpe_vocab,

--- a/laserembeddings/utils.py
+++ b/laserembeddings/utils.py
@@ -1,35 +1,23 @@
-from typing import TextIO
+from io import TextIOBase, StringIO
+import re
 
-__all__ = ['BPECodesAdapter', 'sre_performance_patch']
+__all__ = ['adapt_bpe_codes', 'sre_performance_patch']
 
 
-class BPECodesAdapter:
+def adapt_bpe_codes(bpe_codes_f: TextIOBase) -> TextIOBase:
     """
-    A file object kind-of wrapper converting fastBPE codes to subword_nmt BPE codes.
+    Converts fastBPE codes to subword_nmt BPE codes.
 
     Args:
-        bpe_codes_f (TextIO): the text-mode file object of fastBPE codes
+        bpe_codes_f (TextIOBase): the text-mode file-like object of fastBPE codes
+    Returns:
+        TextIOBase: subword_nmt-compatible BPE codes as a text-mode file-like object
     """
-
-    def __init__(self, bpe_codes_f: TextIO):
-        self.bpe_codes_f = bpe_codes_f
-
-    def seek(self, offset: int, whence: int = 0) -> int:
-        return self.bpe_codes_f.seek(offset, whence)
-
-    def readline(self, limit: int = -1) -> str:
-        return self._adapt_line(self.bpe_codes_f.readline(limit))
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        return self._adapt_line(next(self.bpe_codes_f))
-
-    @staticmethod
-    def _adapt_line(line: str) -> str:
-        parts = line.strip('\r\n ').split(' ')
-        return ' '.join(parts[:-1]) + '\n' if len(parts) == 3 else line
+    return StringIO(
+        re.sub(r'^([^ ]+) ([^ ]+) ([^ ]+)$',
+               r'\1 \2',
+               bpe_codes_f.read(),
+               flags=re.MULTILINE))
 
 
 class sre_performance_patch:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/yannvgn/laserembeddings"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.6.2"
 torch = "^1.0.1.post2"
 subword-nmt = "^0.3.6"
 numpy = "^1.15.4"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,20 +1,20 @@
 from io import StringIO
 
-from laserembeddings.utils import BPECodesAdapter, sre_performance_patch
+from laserembeddings.utils import adapt_bpe_codes, sre_performance_patch
 
 
 def test_bpe_codes_adapter():
     test_f = StringIO(
         '#version:2.0\ne n 52708119\ne r 51024442\ne n</w> 47209692')
 
-    adapted = BPECodesAdapter(test_f)
+    adapted = adapt_bpe_codes(test_f)
 
     assert adapted.readline() == '#version:2.0\n'
     assert adapted.readline() == 'e n\n'
     assert adapted.readline() == 'e r\n'
 
     for line in adapted:
-        assert line == 'e n</w>\n'
+        assert line == 'e n</w>'
 
     adapted.seek(0)
 


### PR DESCRIPTION
Fixes #37
Fixes #38

`BPECodesAdapter` is not compatible with subword-mnt 0.3.8. It is now replaced by `adapt_bpe_codes`, which returns a real `TextIOBase` (more precisely `StringIO`) object.